### PR TITLE
Fix saving of drafts/revisions saving text instead of JSON

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -100,7 +100,7 @@ def pre_page_revision_save(sender, instance, **kwargs):
                     #  Replace content field
                     setattr(mirror_page, field.name, clean_field)
                     #  To json again
-                    instance.content = mirror_page.to_json()
+                    instance.content = mirror_page.serializable_data()
 
 
 @receiver(post_save)


### PR DESCRIPTION
With WT3s change to using JSONFields for revision content, we need to tweak the `pre_save_revision` hook we have to stop converting the JSON to text

I think we can probably get rid of this hook all together in later upgrades.

Fixes https://springload-sentry.sentry.io/issues/6603301043/